### PR TITLE
Fix multi touch exception

### DIFF
--- a/parallaxbacklayout/src/main/java/com/github/anzewei/parallaxbacklayout/ViewDragHelper.java
+++ b/parallaxbacklayout/src/main/java/com/github/anzewei/parallaxbacklayout/ViewDragHelper.java
@@ -1226,6 +1226,9 @@ public class ViewDragHelper {
             case MotionEvent.ACTION_MOVE: {
                 if (mDragState == STATE_DRAGGING) {
                     final int index = ev.findPointerIndex(mActivePointerId);
+                    if (ev.getPointerCount() <= index || index < 0){
+                        return;
+                    }
                     final float x = ev.getX( index);
                     final float y = ev.getY(index);
                     final int idx = (int) (x - mLastMotionX[mActivePointerId]);

--- a/parallaxbacklayout/src/main/java/com/github/anzewei/parallaxbacklayout/widget/ParallaxBackLayout.java
+++ b/parallaxbacklayout/src/main/java/com/github/anzewei/parallaxbacklayout/widget/ParallaxBackLayout.java
@@ -161,6 +161,8 @@ public class ParallaxBackLayout extends FrameLayout {
             // FIXME: handle exception
             // issues #9
             return false;
+        } catch (IllegalArgumentException iae){
+            return false;
         }
     }
 


### PR DESCRIPTION
The `event.findPointerIndex()` might return -1 if there is no data available for that pointer identifier.
So the `ev.getX(index)` will cause `IllegalArgumentException`.

Ref:  https://developer.android.com/reference/android/view/MotionEvent#findPointerIndex(int)

---
Exception detail:
```
java.lang.IllegalArgumentException

pointerIndex out of range
android.view.MotionEvent.nativeGetAxisValue(Native Method)
android.view.MotionEvent.getX(MotionEvent.java:2122)
com.github.anzewei.parallaxbacklayout.ViewDragHelper.void processTouchEvent(android.view.MotionEvent)(TbsSdkJava:1229)
com.github.anzewei.parallaxbacklayout.widget.ParallaxBackLayout.boolean onTouchEvent(android.view.MotionEvent)(TbsSdkJava:173)
android.view.View.dispatchTouchEvent(View.java:10054)
android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2657)
android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2322)
android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2663)
android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2336)
```